### PR TITLE
update: 添加官方源和镜像源链接到 README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 SeaLantern 插件市场的静态站点，用于展示和分发 SeaLantern 插件。
 
+- [官方源: https://sealantern-studio.github.io/plugin-market/](https://sealantern-studio.github.io/plugin-market/)
+- [官方镜像源: https://sealantern-studio.needhelp.icu/](https://sealantern-studio.needhelp.icu/)
+
 ## 核心思路
 
 - 页面只访问 GitHub Pages 提供的静态 API：`/api/plugins.json`、`/api/categories.json`


### PR DESCRIPTION
## 由 Sourcery 生成的摘要

文档：
- 在 README 中添加指向官方 SeaLantern 插件市场源及其镜像端点的链接。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add links in the README to the official SeaLantern plugin market source and its mirror endpoint.

</details>